### PR TITLE
Dev

### DIFF
--- a/components/MovieCard.vue
+++ b/components/MovieCard.vue
@@ -41,7 +41,7 @@
 
     <!-- Movie Info -->
     <div class="p-4">
-      <h3 class="font-bold text-lg text-gray-900 mb-1 group-hover:text-blue-600 transition-colors">
+      <h3 class="font-bold text-lg text-gray-900 mb-1 group-hover:text-blue-600 transition-colors line-clamp-2 leading-tight">
         {{ movie.title }}
       </h3>
       <div class="flex items-center gap-2 mb-2">

--- a/components/PausedShowsWidget.vue
+++ b/components/PausedShowsWidget.vue
@@ -44,7 +44,7 @@
           <div class="flex-1 min-w-0">
             <div class="flex items-start justify-between mb-2">
               <div>
-                <h3 class="font-medium text-gray-900">
+                <h3 class="font-medium text-gray-900 truncate">
                   {{ show.title || show.media_item?.title }}
                   <span v-if="show.season_number" class="text-purple-600 font-semibold">
                     - Season {{ show.season_number }}

--- a/composables/useTrending.ts
+++ b/composables/useTrending.ts
@@ -150,7 +150,7 @@ export const useTrending = () => {
       id: item.tmdb_id,
       title: truncateTitle(item.title, 60), // Truncate long titles for better UI display
       poster: item.poster_path ? `${tmdbImageBaseUrl}${item.poster_path}` : '',
-      rating: item.tmdb_rating ? Number((item.tmdb_rating / 2).toFixed(1)) : 0, // Convert to 5-star rating
+      rating: item.tmdb_rating ? Number(item.tmdb_rating.toFixed(1)) : 0, // Use raw TMDB rating
       genres: item.genres || [],
       year: item.release_year || new Date(item.release_date || '').getFullYear() || 0,
       duration: item.runtime ? `${Math.floor(item.runtime / 60)}h ${item.runtime % 60}m` : '',

--- a/composables/useTrending.ts
+++ b/composables/useTrending.ts
@@ -148,7 +148,7 @@ export const useTrending = () => {
     
     return {
       id: item.tmdb_id,
-      title: item.title,
+      title: truncateTitle(item.title, 60), // Truncate long titles for better UI display
       poster: item.poster_path ? `${tmdbImageBaseUrl}${item.poster_path}` : '',
       rating: item.tmdb_rating ? Number((item.tmdb_rating / 2).toFixed(1)) : 0, // Convert to 5-star rating
       genres: item.genres || [],
@@ -159,6 +159,24 @@ export const useTrending = () => {
       type: item.type,
       tmdb_id: item.tmdb_id
     }
+  }
+
+  // Utility function to truncate long titles
+  const truncateTitle = (title: string, maxLength: number = 60): string => {
+    if (!title) return ''
+    
+    // Simple truncation if title is too long
+    if (title.length > maxLength) {
+      const truncated = title.substring(0, maxLength)
+      const lastSpace = truncated.lastIndexOf(' ')
+      if (lastSpace > maxLength * 0.7) {
+        return truncated.substring(0, lastSpace) + '...'
+      } else {
+        return truncated + '...'
+      }
+    }
+    
+    return title
   }
 
   // Get trending movies formatted for UI
@@ -186,6 +204,7 @@ export const useTrending = () => {
     getTrendingMovies,
     getTrendingTVShows,
     getTrendingByPlatformForUI,
-    transformTrendingToMovie
+    transformTrendingToMovie,
+    truncateTitle
   }
 }

--- a/composables/useTrending.ts
+++ b/composables/useTrending.ts
@@ -1,0 +1,191 @@
+export interface TrendingItem {
+  id: number
+  title: string
+  tmdb_id: number
+  type: 'movie' | 'tv'
+  platform: string
+  tmdb_rating?: number
+  tmdb_vote_count?: number
+  genres?: string[]
+  poster_path?: string
+  backdrop_path?: string
+  release_year?: number
+  release_date?: string
+  trailer_url?: string
+  overview?: string
+  runtime?: number
+  language?: string
+  popularity?: number
+  trending_score?: number
+  trending_rank?: number
+  is_active: boolean
+  expires_at?: string
+  metadata?: any
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TrendingFilters {
+  type?: 'movie' | 'tv'
+  platform?: string
+  limit?: number
+}
+
+export const useTrending = () => {
+  const config = useRuntimeConfig()
+  
+  // Direct API calls to Strapi
+  const apiCall = async (endpoint: string, options: any = {}) => {
+    const strapiUrl = config.public.strapiUrl || 'http://localhost:1337'
+    
+    return await $fetch(`${strapiUrl}/api${endpoint}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...options.headers
+      },
+      ...options
+    })
+  }
+
+  // Get active trending items
+  const getActiveTrending = async (filters: TrendingFilters = {}): Promise<TrendingItem[]> => {
+    try {
+      const params = new URLSearchParams()
+      
+      if (filters.type) params.append('type', filters.type)
+      if (filters.platform) params.append('platform', filters.platform)
+      if (filters.limit) params.append('limit', filters.limit.toString())
+      
+      const queryString = params.toString()
+      const endpoint = `/trendings/active${queryString ? `?${queryString}` : ''}`
+      
+      const response = await apiCall(endpoint)
+      return response as TrendingItem[]
+    } catch (error) {
+      console.error('Error fetching active trending items:', error)
+      return []
+    }
+  }
+
+  // Get trending items by platform
+  const getTrendingByPlatform = async (platform: string, filters: Omit<TrendingFilters, 'platform'> = {}): Promise<TrendingItem[]> => {
+    try {
+      const params = new URLSearchParams()
+      
+      if (filters.type) params.append('type', filters.type)
+      if (filters.limit) params.append('limit', filters.limit.toString())
+      
+      const queryString = params.toString()
+      const endpoint = `/trendings/platform/${platform}${queryString ? `?${queryString}` : ''}`
+      
+      const response = await apiCall(endpoint)
+      return response as TrendingItem[]
+    } catch (error) {
+      console.error(`Error fetching trending items for platform ${platform}:`, error)
+      return []
+    }
+  }
+
+  // Get all trending items (with pagination)
+  const getAllTrending = async (filters: TrendingFilters & { page?: number, pageSize?: number } = {}): Promise<{
+    data: TrendingItem[]
+    meta: {
+      pagination: {
+        page: number
+        pageSize: number
+        pageCount: number
+        total: number
+      }
+    }
+  }> => {
+    try {
+      const params = new URLSearchParams()
+      
+      if (filters.type) params.append('filters[type][$eq]', filters.type)
+      if (filters.platform) params.append('filters[platform][$eq]', filters.platform)
+      if (filters.limit) params.append('pagination[pageSize]', filters.limit.toString())
+      if (filters.page) params.append('pagination[page]', filters.page.toString())
+      if (filters.pageSize) params.append('pagination[pageSize]', filters.pageSize.toString())
+      
+      // Add sorting
+      params.append('sort[0]', 'trending_rank:asc')
+      params.append('sort[1]', 'trending_score:desc')
+      
+      const queryString = params.toString()
+      const endpoint = `/trendings${queryString ? `?${queryString}` : ''}`
+      
+      const response = await apiCall(endpoint) as {
+        data: TrendingItem[]
+        meta: {
+          pagination: {
+            page: number
+            pageSize: number
+            pageCount: number
+            total: number
+          }
+        }
+      }
+      return response
+    } catch (error) {
+      console.error('Error fetching all trending items:', error)
+      return {
+        data: [],
+        meta: {
+          pagination: {
+            page: 1,
+            pageSize: 25,
+            pageCount: 0,
+            total: 0
+          }
+        }
+      }
+    }
+  }
+
+  // Transform trending item to match Movie interface used in UI
+  const transformTrendingToMovie = (item: TrendingItem) => {
+    const tmdbImageBaseUrl = 'https://image.tmdb.org/t/p/w500'
+    
+    return {
+      id: item.tmdb_id,
+      title: item.title,
+      poster: item.poster_path ? `${tmdbImageBaseUrl}${item.poster_path}` : '',
+      rating: item.tmdb_rating ? Number((item.tmdb_rating / 2).toFixed(1)) : 0, // Convert to 5-star rating
+      genres: item.genres || [],
+      year: item.release_year || new Date(item.release_date || '').getFullYear() || 0,
+      duration: item.runtime ? `${Math.floor(item.runtime / 60)}h ${item.runtime % 60}m` : '',
+      trailerUrl: item.trailer_url || '',
+      platform: item.platform,
+      type: item.type,
+      tmdb_id: item.tmdb_id
+    }
+  }
+
+  // Get trending movies formatted for UI
+  const getTrendingMovies = async (limit: number = 10) => {
+    const trendingItems = await getActiveTrending({ type: 'movie', limit })
+    return trendingItems.map(transformTrendingToMovie)
+  }
+
+  // Get trending TV shows formatted for UI
+  const getTrendingTVShows = async (limit: number = 10) => {
+    const trendingItems = await getActiveTrending({ type: 'tv', limit })
+    return trendingItems.map(transformTrendingToMovie)
+  }
+
+  // Get trending by platform formatted for UI
+  const getTrendingByPlatformForUI = async (platform: string, limit: number = 10) => {
+    const trendingItems = await getTrendingByPlatform(platform, { limit })
+    return trendingItems.map(transformTrendingToMovie)
+  }
+
+  return {
+    getActiveTrending,
+    getTrendingByPlatform,
+    getAllTrending,
+    getTrendingMovies,
+    getTrendingTVShows,
+    getTrendingByPlatformForUI,
+    transformTrendingToMovie
+  }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -132,12 +132,17 @@
 </template>
 
 <script setup lang="ts">
+// Import composables explicitly
+import { useTrending } from '~/composables/useTrending'
+
 // Protect this page with authentication middleware
 definePageMeta({
   middleware: 'auth'
 })
 
+// Import composables
 const { user } = useAuth()
+const { getTrendingMovies } = useTrending()
 
 // Mobile Menu State
 const showMobileMenu = ref(false)
@@ -168,38 +173,52 @@ interface Movie {
 }
 
 // Sample movie data - replace with API calls later
-const trendingMovies = ref<Movie[]>([
-  {
-    id: 1,
-    title: "Openheimer",
-    poster:"https://www.themoviedb.org/t/p/w1280/8Gxv8gSFCU0XGDykEGv7zR1n2ua.jpg",
-    rating: 4.8,
-    genres: ["Thriller", "Detective"],
-    year: 2023,
-    duration: "2h 57m",
-    trailerUrl: "https://youtu.be/bK6ldnjE3Y0"
-  },
-  {
-    id: 2,
-    title: "The Witcher",
-    poster:"https://www.themoviedb.org/t/p/w1280/cZ0d3rtvXPVvuiX22sP79K3Hmjz.jpg",
-    rating: 4.2,
-    genres: ["Drama", "Adventure"],
-    year: 2023,
-    duration: "1h 45m",
-    trailerUrl: "https://www.youtube.com/watch?v=ndl1W4ltcmg"
-  },
-  {
-    id: 3,
-    title: "The Marvels",
-    poster:"https://www.themoviedb.org/t/p/w1280/9GBhzXMFjgcZ3FdR9w3bUMMTps5.jpg",
-    rating: 3.5,
-    genres: ["Action", "Adventure"],
-    year: 2023,
-    duration: "1h 45m",
-    trailerUrl: "https://www.youtube.com/watch?v=wS_qbDztgVY"
+const trendingMovies = ref<Movie[]>([])
+
+// Load trending movies from API
+
+// Load trending data on mount
+onMounted(async () => {
+  try {
+    const trending = await getTrendingMovies(6) // Get 6 trending movies
+    trendingMovies.value = trending
+  } catch (error) {
+    console.error('Error loading trending movies:', error)
+    // Fallback to hardcoded data if API fails
+    trendingMovies.value = [
+      {
+        id: 1,
+        title: "Openheimer",
+        poster:"https://www.themoviedb.org/t/p/w1280/8Gxv8gSFCU0XGDykEGv7zR1n2ua.jpg",
+        rating: 4.8,
+        genres: ["Thriller", "Detective"],
+        year: 2023,
+        duration: "2h 57m",
+        trailerUrl: "https://youtu.be/bK6ldnjE3Y0"
+      },
+      {
+        id: 2,
+        title: "The Witcher",
+        poster:"https://www.themoviedb.org/t/p/w1280/cZ0d3rtvXPVvuiX22sP79K3Hmjz.jpg",
+        rating: 4.2,
+        genres: ["Drama", "Adventure"],
+        year: 2023,
+        duration: "1h 45m",
+        trailerUrl: "https://www.youtube.com/watch?v=ndl1W4ltcmg"
+      },
+      {
+        id: 3,
+        title: "The Marvels",
+        poster:"https://www.themoviedb.org/t/p/w1280/9GBhzXMFjgcZ3FdR9w3bUMMTps5.jpg",
+        rating: 3.5,
+        genres: ["Action", "Adventure"],
+        year: 2023,
+        duration: "1h 45m",
+        trailerUrl: "https://www.youtube.com/watch?v=wS_qbDztgVY"
+      }
+    ]
   }
-])
+})
 
 const comingSoonMovies = ref<Movie[]>([
   {


### PR DESCRIPTION
This pull request introduces several improvements to the UI and backend integration for trending movies and TV shows. Key changes include enhancing text display in UI components, adding a new composable for fetching trending data from an API, and integrating this data into the homepage.

### UI Enhancements:
* [`components/MovieCard.vue`](diffhunk://#diff-1fcbeb8bdef6f44d5a7ebd8896ff07bee7e9cb71f897bb1bf5a4a3ef60b09824L44-R44): Added `line-clamp-2` and `leading-tight` classes to limit movie titles to two lines and improve readability.
* [`components/PausedShowsWidget.vue`](diffhunk://#diff-f1065b93a3969939c3089940ea217495bd39e933819f673555f86623771dbffbL47-R47): Added `truncate` class to truncate long show titles, ensuring they fit within the UI layout.

### Backend Integration:
* [`composables/useTrending.ts`](diffhunk://#diff-1553cc7fa4ef43bae7b402dafdd0c70e236879d66b3f33f2bd667fa8927064e5R1-R210): Introduced a new composable with interfaces and methods for fetching trending data from an API, including filtering, pagination, and transforming data for UI use.

### Homepage Integration:
* [`pages/index.vue`](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfR135-R145): Integrated the `useTrending` composable to fetch and display trending movies dynamically on the homepage, replacing hardcoded sample data. Added error handling with a fallback to static data. [[1]](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfR135-R145) [[2]](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfL171-R188) [[3]](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfL202-R221)